### PR TITLE
DATAUP-515: Fix staging service 500 on deleting export

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,3 +12,7 @@ Adding KbaseMetagenomes.AnnotatedMetagenomeAssembly exporter with staging.
 1.0.5
 -----
 Adding KBaseSets.SampleSet exporter with staging.
+
+1.0.6
+-----
+Add group write permissions to staging area files so the staging service can delete them.

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.5
+    1.0.6
 
 owners:
-    [tgu2, slebras]
+    [tgu2, slebras, gaprice]

--- a/lib/kb_staging_exporter/Utils/staging_downloader.py
+++ b/lib/kb_staging_exporter/Utils/staging_downloader.py
@@ -353,7 +353,8 @@ class staging_downloader:
         # so if we add write privs to the root group that solves the issue.
         # Longer term this app should not run as root and should chown ownership to the staging
         # service when it has a static user name vs. a number that might change.
-        self._recursive_chmod(staging_dir, stat.S_IWGRP)
+        basemode = os.stat(staging_dir).st_mode
+        self._recursive_chmod(staging_dir, basemode | stat.S_IWGRP)
         
         if not (set(os.listdir(staging_dir)) >= set(files)):
             raise ValueError('Unexpected error occurred during copying files')

--- a/test/kb_staging_exporter_server_test.py
+++ b/test/kb_staging_exporter_server_test.py
@@ -2,7 +2,6 @@
 import unittest
 import os  # noqa: F401
 import json  # noqa: F401
-import stat
 import time
 import requests  # noqa: F401
 import inspect

--- a/test/kb_staging_exporter_server_test.py
+++ b/test/kb_staging_exporter_server_test.py
@@ -272,9 +272,10 @@ class kb_staging_exporterTest(unittest.TestCase):
         #                  self.READS_FASTQ_MD5)
 
         # test that the group write permission is correctly added to the new files
-        assert bool(os.stat(staging_dir).st_mode & stat.S_IWGRP), staging_dir
+        # and the old permissions are otherwise retained
+        self.assertEqual(os.stat(staging_dir).st_mode, 0o040775, staging_dir)
         for f in staging_files:
-            assert bool(os.stat(os.path.join(staging_dir, f)).st_mode & stat.S_IWGRP), f
+            self.assertEqual(os.stat(os.path.join(staging_dir, f)).st_mode, 0o100775, f)
 
     @patch.object(staging_downloader, "STAGING_USER_FILE_PREFIX", new='/kb/module/work/tmp/')
     def test_export_to_staging_assembly_ok(self):

--- a/test/kb_staging_exporter_server_test.py
+++ b/test/kb_staging_exporter_server_test.py
@@ -2,6 +2,7 @@
 import unittest
 import os  # noqa: F401
 import json  # noqa: F401
+import stat
 import time
 import requests  # noqa: F401
 import inspect
@@ -244,6 +245,9 @@ class kb_staging_exporterTest(unittest.TestCase):
 
     @patch.object(staging_downloader, "STAGING_USER_FILE_PREFIX", new='/kb/module/work/tmp/')
     def test_export_to_staging_reads_ok(self):
+        """
+        Also tests that the downloaded files have the correct group write permission.
+        """
         self.start_test()
 
         test_Reads = self.loadReads()
@@ -257,8 +261,8 @@ class kb_staging_exporterTest(unittest.TestCase):
 
         reads_files = os.listdir(ret['result_dir'])
 
-        staging_files = os.listdir(os.path.join('/kb/module/work/tmp/',
-                                                destination_dir))
+        staging_dir = os.path.join('/kb/module/work/tmp/', destination_dir)
+        staging_files = os.listdir(staging_dir)
         self.assertTrue(set(staging_files) >= set(reads_files))
 
         self.assertEqual(len(reads_files), 1)
@@ -266,6 +270,11 @@ class kb_staging_exporterTest(unittest.TestCase):
         self.assertTrue(reads_file_name.startswith('test_Reads'))
         # self.assertEqual(self.md5(os.path.join(ret['result_dir'], reads_file_name)),
         #                  self.READS_FASTQ_MD5)
+
+        # test that the group write permission is correctly added to the new files
+        assert bool(os.stat(staging_dir).st_mode & stat.S_IWGRP), staging_dir
+        for f in staging_files:
+            assert bool(os.stat(os.path.join(staging_dir, f)).st_mode & stat.S_IWGRP), f
 
     @patch.object(staging_downloader, "STAGING_USER_FILE_PREFIX", new='/kb/module/work/tmp/')
     def test_export_to_staging_assembly_ok(self):


### PR DESCRIPTION
The staging service cannot currently delete any files or folders created by
the exporter because the staging service runs as user 800 (at least in CI)
and this app runs as root (yuck). However,  both the service and this app
are part of the root group, so adding write permissions to that group should
allow the staging service to delete files. This is a shorter term fix -
the longer term fix would be to use sane user names for both processes,
and possibly have the exporter chown to the staging service.