### PR TITLE
Fix tests w/ patched SDK

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -14,20 +14,12 @@ on:
 jobs:
 
   sdk_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Check out GitHub repo
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       uses: actions/checkout@v2
-
-    - name: Check out Actions CI files
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      uses: actions/checkout@v2
-      with:
-        repository: 'kbaseapps/kb_sdk_actions'
-        path: 'kb_sdk_actions'
-
 
     - name: Set up test environment
       if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -35,12 +27,7 @@ jobs:
       env:
         KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
       run: |
-        # Verify kb_sdk_actions clone worked
-        test -f "$HOME/kb_sdk_actions/bin/kb-sdk" && echo "CI files cloned"
-        # Pull kb-sdk & create startup script
-        docker pull kbase/kb-sdk
-       
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir && echo "Created test_local"
+        sh scripts/GHA/make_testdir && echo "Created test_local"
         test -f "test_local/test.cfg" && echo "Confirmed config exists"
 
     - name: Configure authentication
@@ -55,10 +42,8 @@ jobs:
     - name: Run tests
       if: "!contains(github.event.head_commit.message, 'skip ci')"
       shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
+        sh scripts/GHA/kb-sdk test --verbose
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/scripts/GHA/kb-sdk
+++ b/scripts/GHA/kb-sdk
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# TODO pin sdk image when pinnable tags are available
+# TODO may want to make the image an env var or argument
+
+# See https://github.com/kbaseapps/kb_sdk_actions/blob/master/bin/kb-sdk for source
+
+# Cache the group for the docker file
+if [ ! -e $HOME/.kbsdk.cache ] ; then
+  docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls ghcr.io/kbase/kb_sdk_patch-develop:br-main -l /var/run/docker.sock|awk '{print $4}' > $HOME/.kbsdk.cache
+fi
+
+exec docker run -i --rm -v $HOME:$HOME -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock -e DSHELL=$SHELL --group-add $(cat $HOME/.kbsdk.cache) ghcr.io/kbase/kb_sdk_patch-develop:br-main $@

--- a/scripts/GHA/make_testdir
+++ b/scripts/GHA/make_testdir
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# TODO pin sdk image when pinnable tags are available
+# TODO may want to make the image an env var or argument
+
+# See https://github.com/kbaseapps/kb_sdk_actions/blob/master/bin/make_testdir for source
+
+# Disable the default `return 1` when creating `test_local`
+set +e
+
+# Cache the group for the docker file
+if [ ! -e $HOME/.kbsdk.cache ] ; then
+  docker run -i -v /var/run/docker.sock:/var/run/docker.sock --entrypoint ls ghcr.io/kbase/kb_sdk_patch-develop:br-main -l /var/run/docker.sock|awk '{print $4}' > $HOME/.kbsdk.cache
+fi
+
+exec docker run -i --rm -v $HOME:$HOME -u $(id -u) -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock  -e DUSER=$USER -e DSHELL=$SHELL --group-add $(cat $HOME/.kbsdk.cache) ghcr.io/kbase/kb_sdk_patch-develop:br-main test
+exit


### PR DESCRIPTION
The tests are currently failing because the SDK client in the image is too old to work with the docker server on even the oldest ubuntu version in GHA.

This hack uses the patched SDK with newer docker binaries and copies and alters kb_sdk_actions scripts to run the image as root.

It may be possible in the future to no longer run images as root if we can figure out why the docker changes currently require it, but that's another fix.

It should also be noted that the prior sdk image isn't pinnned, which isn't great. The new image tag doesn't appear to be pinnable either but that may change in the near future.