### PR TITLE
Update app to use results tab text

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # kb_staging_exporter release notes
 =========================================
 
+1.0.10
+------
+
+* Updated the JSON download app to use the new result tab output system.
+
 1.0.9
 -----
 * Fixed a bug that caused the export_json_to_staging app to fail with a JSON marshalling

--- a/kb_staging_exporter.spec
+++ b/kb_staging_exporter.spec
@@ -61,9 +61,12 @@ module kb_staging_exporter {
   /* Result of the export_json_to_staging function.
      
      result_dir - the location in shared scratch space where the compressed object was stored.
+     result_text - text describing the result of the app run suitable for displaying to a
+         Narrative user.
   */
   typedef structure {
     string result_dir;
+    string result_text;
   } ExportJSONResult;
 
   /* Download JSON object data for a workspace object and store it in zip file in the staging

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.9
+    1.0.10
 
 owners:
     [tgu2, slebras, gaprice]

--- a/lib/kb_staging_exporter/Utils/staging_downloader.py
+++ b/lib/kb_staging_exporter/Utils/staging_downloader.py
@@ -458,8 +458,13 @@ class staging_downloader:
             }
         else:
             writeobjs = {cleanname + ".json": obj}
-        with ZipFile(result_dir / (cleanname + ".json.zip"), 'w', ZIP_DEFLATED) as z:
+        zipfile = cleanname + ".json.zip"
+        with ZipFile(result_dir / zipfile, 'w', ZIP_DEFLATED) as z:
             for fn, o in writeobjs.items():
                 z.writestr(fn, json.dumps(o, indent=4))
         self._move_results_to_staging(ctx, destination_dir, result_dir)
-        return {"result_dir": str(result_dir)}
+        return {
+            "result_dir": str(result_dir),
+            "result_text": "Successfully exported JSON to staging area in file "
+                + os.path.join(destination_dir, zipfile)
+        }

--- a/lib/kb_staging_exporter/kb_staging_exporterImpl.py
+++ b/lib/kb_staging_exporter/kb_staging_exporterImpl.py
@@ -21,9 +21,9 @@ class kb_staging_exporter:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.0.9"
+    VERSION = "1.0.10"
     GIT_URL = "https://github.com/kbaseapps/kb_staging_exporter.git"
-    GIT_COMMIT_HASH = "333975ed017749775fe8321a99a9d8a3bb6c6494"
+    GIT_COMMIT_HASH = "6474e72609024af56e142156a73ca94605f5f05e"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -94,8 +94,10 @@ class kb_staging_exporter:
            "destination_dir" of String, parameter "format" of String
         :returns: instance of type "ExportJSONResult" (Result of the
            export_json_to_staging function. result_dir - the location in
-           shared scratch space where the compressed object was stored.) ->
-           structure: parameter "result_dir" of String
+           shared scratch space where the compressed object was stored.
+           result_text - text describing the result of the app run suitable
+           for displaying to a Narrative user.) -> structure: parameter
+           "result_dir" of String, parameter "result_text" of String
         """
         # ctx is the context object
         # return variables are: ret

--- a/test/kb_staging_exporter_server_test.py
+++ b/test/kb_staging_exporter_server_test.py
@@ -484,7 +484,10 @@ class kb_staging_exporterTest(unittest.TestCase):
                 ("  standard   ", "jsonthree")
             ]:
             params = {"input_ref": upa, "destination_dir": ddir, "format": format}
-            resdir = self.serviceImpl.export_json_to_staging(self.ctx, params)[0]["result_dir"]
+            res = self.serviceImpl.export_json_to_staging(self.ctx, params)[0]
+            assert res["result_text"] == (
+                f"Successfully exported JSON to staging area in file {ddir}/json_test.json.zip")
+            resdir = res["result_dir"]
             assert resdir.startswith("/kb/module/work/tmp/") is True
             staging_dir = Path("/kb/module/work/tmp/") / ddir
             staging_file = staging_dir / (filename + ".zip")
@@ -564,7 +567,10 @@ class kb_staging_exporterTest(unittest.TestCase):
             "destination_dir": "legacy",
             "format": "legacy_data_import_export"
         }
-        resdir = self.serviceImpl.export_json_to_staging(self.ctx, params)[0]["result_dir"]
+        res = self.serviceImpl.export_json_to_staging(self.ctx, params)[0]
+        assert res["result_text"] == (
+                "Successfully exported JSON to staging area in file legacy/legacytest.json.zip")
+        resdir = res["result_dir"]
         assert resdir.startswith("/kb/module/work/tmp/") is True
         staging_dir = Path("/kb/module/work/tmp/") / self.ctx["user_id"] / "legacy"
         staging_file = staging_dir / (fileroot + ".json.zip")

--- a/ui/narrative/methods/export_json_to_staging/spec.json
+++ b/ui/narrative/methods/export_json_to_staging/spec.json
@@ -6,7 +6,7 @@
   "categories" : ["active","util"],
   "widgets": {
     "input": null,
-    "output" : "no-display"
+    "output" : "text-only"
   },
   "parameters" : [
     {
@@ -69,7 +69,12 @@
           "target_property" : "format"
         }
       ],
-      "output_mapping": []
+      "output_mapping": [
+        {
+          "service_method_output_path": [0, "result_text"],
+          "target_property": "result_text"
+        }
+      ]
     }
   },
   "job_id_output_field": "docker"


### PR DESCRIPTION
Changes the app to add text to the results tab via the new `text-only` output type, which allows for a small amount of text to be displayed in the output tab rather than having to create a report